### PR TITLE
Add language specifiers to fenced code blocks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,27 +27,37 @@ Lark is a SOAP library written in Swift.
 
 First, install the package by including the following in `Package.swift`:
 
-    .Package(url: "https://github.com/Bouke/Lark.git", majorVersion: 0)
+```swift
+.Package(url: "https://github.com/Bouke/Lark.git", majorVersion: 0)
+```
 
 Then, build your package. This will result in an executable named `lark-generate-client` which can generate the client code:
 
-    swift build
-    .build/debug/lark-generate-client "http://localhost:8000/?wsdl" > Sources/Client.swift
+```sh
+swift build
+.build/debug/lark-generate-client "http://localhost:8000/?wsdl" > Sources/Client.swift
+```
 
 In your code you can now use the generated `Client` like this:
 
-    let client = HelloWorldServiceClient()
+```swift
+let client = HelloWorldServiceClient()
+```
 
 To call a remote method, inspect the generated functions on the Client. For example the `sayHello` method that takes a `SayHello` parameter and returns a `SayHelloResponse`:
 
-    let result = try client.sayHello(SayHello(name: "World", times: 2))
-    print(result.sayHelloResult)
+```swift
+let result = try client.sayHello(SayHello(name: "World", times: 2))
+print(result.sayHelloResult)
+```
 
 Or if you're building a GUI that requires non-blocking networking, use the async version:
 
-    client.sayHelloAsync(SayHello(name: "World", times: 2)) { result in
-        print(result?.value.sayHelloResult)
-    }
+```swift
+client.sayHelloAsync(SayHello(name: "World", times: 2)) { result in
+    print(result?.value.sayHelloResult)
+}
+```
 
 ## Example
 


### PR DESCRIPTION
Enables syntax highlighting on GitHub.

## Description
Adding language specifiers to fenced code blocks enables syntax highlighting in GitHub-flavored Markdown.

## Motivation and Context
ReadMe pages look nicer when they have syntax highlighting enabled.

## How Has This Been Tested?
Previewed the code in GitHub's rich Markdown changes previewer.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- N/A I have added tests to cover my changes.
- N/A All new and existing tests passed.
